### PR TITLE
Fix for /is coorperate usage

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,5 +3,5 @@ description: A powerful core for SkyBlock servers
 author: GiantQuartz
 website: twitter.com/GiantQuartz
 main: room17\SkyBlock\SkyBlock
-version: 2.2.5
+version: 2.2.6
 api: [3.0.0]

--- a/resources/messages.json
+++ b/resources/messages.json
@@ -104,6 +104,7 @@
   "NOW_YOU_CAN_COOPERATE": "{WHITE}{name} {GREEN}gave you permission to cooperate in his island!",
   "REMOVED_A_COOPERATOR": "{WHITE}{name} {GREEN}is no longer a cooperator!",
   "NOW_YOU_CANNOT_COOPERATE": "{WHITE}{name} {GREEN}revoked you the permission to cooperate in his island!",
+  "COOPERATE_USAGE": "{WHITE}Usage: /is cooperate <player>",
   "COOPERATE_DESCRIPTION": "Allows another player to interact with your isle",
   "YOU_HAVE_TO_WAIT": "{YELLOW}To create another island you have to wait {WHITE}{minutes} {YELLOW}minutes!"
 }


### PR DESCRIPTION
This PR is a small fix. This fixes /is cooperate usage from coming up with a message error, and not showing anything a part from The message Cooperate_usage not found. This can be fixed by just simply adding cooperate_usage to config.yml, which should fix the problem.
This has been tested, and is to work on this PR of the plugin. Please merge it when possible, thank you!