### PR TITLE
Fix blocked commands issue.

### DIFF
--- a/src/room17/SkyBlock/SkyBlockListener.php
+++ b/src/room17/SkyBlock/SkyBlockListener.php
@@ -201,19 +201,21 @@ class SkyBlockListener implements Listener {
         }
     }
 
-    /**
+     /**
      * @param PlayerCommandPreprocessEvent $event
      */
     public function onCommand(PlayerCommandPreprocessEvent $event): void {
         $message = $event->getMessage();
         $player = $event->getPlayer();
-        if($this->isleManager->getIsle($player->getLevel()->getName()) != null and
-            $message{0} == "/" and
-            in_array(strtolower(substr($message, 1)), $this->plugin->getSettings()->getIsleBlockedCommands())
-        ) {
+        if($this->isleManager->getIsle($player->getLevel()->getName()) != null){
+        	$blockedcommands = $this->plugin->getSettings()->getIsleBlockedCommands(); //New way to display a list of blocked commands, which then foreaches, and then detects the blocked commands.
+		foreach($blockedcommands as $blocked) {
+			if(strpos($message, $blocked) !== false) {
             $this->getSession($player)->sendTranslatedMessage("BLOCKED_COMMAND");
             $event->setCancelled();
         }
+    }
+    }
     }
 
     /**


### PR DESCRIPTION
This PR fixes the blocked commands bug, where the command would be blocked, but when using more than 1 argument (more than the actual blocked command, it wouldn't block the command being used. Example: If you type /home (as an example of a blocked command), it would say it's blocked, yes, that works fine, but whenever you type like: /home test, it wouldn't block the command, thus meaning you were able to bypass the system. Now, this fixes the bypass, as tested.
I've also made some tweaking to the blocked commands, so instead  of finding the blocked commands (via "/", and the $message{0}, I've implemented it so it finds the blocked commands using $blockedcommands = $this->plugin->getSettings()->getIsleBlockedCommands();
then it foreaches it using foreach($blockedcommands as $blocked) {
Then, it uses if(strpos($message, $blocked) !== false) {
which is my way of implementing it = less buggy, and works more than it used to.
Test before merging (just in case. If it doesn't work as it should do for you, then I'll try and make some fixes, but this should work, as it's been tested to work anyways.)
Thank you!