### PR TITLE
Added permission for creating sky islands.

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -10,3 +10,6 @@ permissions:
   skyblock.interaction:
     description: Allows players to interact with an island regardless of whether they belong to it
     default: op
+  skyblock.allowed:
+    description: Alows players to create their own island.
+    default: op

--- a/src/room17/SkyBlock/command/presets/CreateCommand.php
+++ b/src/room17/SkyBlock/command/presets/CreateCommand.php
@@ -70,6 +70,10 @@ class CreateCommand extends IslandCommand {
             $session->sendTranslatedMessage(new MessageContainer("NEED_TO_BE_FREE"));
             return;
         }
+        if(!$session->getPlayer()->hasPermission("skyblock.allowed")){//if player does not have permission, don't create.
+            $session->getPlayer()->sendMessage('You are not allowed to create sky islands.');
+            return;
+        };
         $minutesSinceLastIsland = $session->getLastIslandCreationTime() !== null
             ? (microtime(true) - $session->getLastIslandCreationTime()) / 60
             : -1;


### PR DESCRIPTION
Implemented skyblock.allowed permission, this ONLY EFFECTS THE CREATION NOTHING ELSE, could definitely use the messageManager class but it works practically like this. :)